### PR TITLE
JDF-707: Replace hardcoded URLs with relative URLs

### DIFF
--- a/guides/CONTRIBUTING.md
+++ b/guides/CONTRIBUTING.md
@@ -18,9 +18,9 @@ To contribute to the quickstarts, fork the quickstart repository to your own Git
 
 If you don't have the Git client (`git`), get it from: <http://git-scm.com/>
 
-Here are the steps in detail:
+This document details the steps needed to contribute to the JBoss EAP quickstarts. For other quickstarts, you need to replace the Github repository URL with the correct repository location.
 
-1. [Fork](https://github.com/jboss-developer/jboss-eap-quickstarts/fork_select) the project. This creates a the project in your own Git with the default remote name 'origin'.
+1. [Fork](https://github.com/jboss-developer/jboss-eap-quickstarts/fork) the project. This creates the `jboss-eap-quickstarts` project in your own Git with the default remote name 'origin'.
 
 2. Clone your fork. This creates and populates a directory in your local file system.
 
@@ -114,7 +114,7 @@ General Guidelines
 
 * If you create a quickstart that uses a database table, make sure the name you use for the table is unique across all quickstarts. 
 
-* The project must follow the structure used by existing quickstarts such as [numberguess](https://github.com/jboss-developer/jboss-eap-quickstarts/tree/master/numberguess). A good starting point would be to copy the  `numberguess` project.
+* The project must follow the structure used by existing quickstarts such as [numberguess](../../../../jboss-eap-quickstarts/tree/master/numberguess). A good starting point would be to copy the  `numberguess` project.
 
 * The sample project should be importable into JBoss Developer Studio/JBoss Tools and be deployable from there.
 

--- a/guides/RUN_ARQUILLIAN_TESTS.md
+++ b/guides/RUN_ARQUILLIAN_TESTS.md
@@ -10,7 +10,7 @@ There are two ways you can run Arquillian tests:
 
 The individual quickstart README should tell you what to expect in the console output and the server log when you run the tests.
 
-_Note:_ If you do not configure the Maven settings as described here, [Configure Maven](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_MAVEN.md#configure-maven-to-build-and-deploy-the-quickstarts), you must pass the configuration setting on every Maven command as follows: ` -s QUICKSTART_HOME/settings.xml`
+_Note:_ If you do not configure the Maven settings as described here, [Configure Maven](../../../blob/master/guides/CONFIGURE_MAVEN.md#configure-maven-to-build-and-deploy-the-quickstarts), you must pass the configuration setting on every Maven command as follows: ` -s QUICKSTART_HOME/settings.xml`
 
 Test the Quickstart on a Remote JBoss EAP Server
 -------------------------------------


### PR DESCRIPTION
I replace the following:
CONTRIBUTING.md: 
- The numberguess link.
- I did not replace the 'Fork' link because it's specific to EAP quickstarts and does not work in your own repository.

RUN_ARQUILLIAN_TEST.md: 
- The Maven instructions link.
