### PR TITLE
The JBoss EAP 6.3 quickstarts reference a file name with a typo. Adding ...

### DIFF
--- a/guides/USE_JDBS.md
+++ b/guides/USE_JDBS.md
@@ -1,0 +1,10 @@
+Use JBoss Developer Studio or Eclipse to Run the Quickstarts
+============================================================
+
+You can also deploy the quickstarts or run the Arquillian tests from Eclipse using JBoss tools. 
+
+For information on how to configure Maven and JBoss Developer Studio (JBDS) for use with the quickstarts, see the [Getting Started Guide](https://access.redhat.com/site/documentation/en-US/JBoss_Enterprise_Application_Platform/6.3/html-single/Getting_Started_Guide/index.html "Getting Started Guide") for JBoss Enterprise Application Platform. 
+
+See [Get Started](http://www.jboss.org/get-started/ "Get Started") on the JBoss Developer web site for additional information.
+
+


### PR DESCRIPTION
...it back to prevent 404 acess errors
